### PR TITLE
Enable GCS gradle remote cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    
+    - name: Restore and export service account to ENV for GCS remote cache
+      run: |
+        echo $GCS_SERVICE_ACCOUNT | base64 --decode --ignore-garbage > service.json
+        echo "GOOGLE_APPLICATION_CREDENTIALS=service.json" >> $GITHUB_ENV
+      if: env.GCS_SERVICE_ACCOUNT
+      env:
+        GCS_SERVICE_ACCOUNT: ${{ secrets.GCS_SERVICE_ACCOUNT }}
+
     # Execute
     - name: Build with Gradle
       run: ./gradlew build --profile

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,22 @@
 
 rootProject.name = "SkyWarehouse"
 
+plugins {
+    id("io.perezalcolea.gcs-build-cache") version "0.1.0"
+}
+
+buildCache {
+    val isCi = System.getenv().containsKey("CI")
+    local {
+        isEnabled = !isCi
+    }
+
+    val enableGoogleApplicationCredentials = System.getenv().containsKey("GOOGLE_APPLICATION_CREDENTIALS")
+    remote<io.perezalcolea.gradle.caching.gcs.GCSBuildCache> {
+        isEnabled = enableGoogleApplicationCredentials
+        applicationName = "skw"
+        bucket = "kesin11_bazel_cache"
+        path = "gradle_cache"
+        isPush = isCi
+    }
+}


### PR DESCRIPTION
Enable Gradle remote build cache
https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_implement

Using GCS as remote cache by this plugin.
https://github.com/rpalcolea/gradle-gcs-build-cache