### PR TITLE
Create archives that includes executable script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,15 @@ jobs:
 
     # Execute
     - name: Build with Gradle
-      run: ./gradlew build --profile
-    
+      run: ./gradlew assembleArchiveDist test --profile
+
     # Post
     - uses: actions/upload-artifact@v2
       with:
-        name: jars
-        path: build/libs
+        name: artifacts
+        path: |
+          build/libs/*.jar
+          build/distributions
       if: always()
     - uses: actions/upload-artifact@v2
       with:
@@ -69,8 +71,9 @@ jobs:
           java-version: ${{ matrix.java }}
       - uses: actions/download-artifact@v2
         with:
-          name: jars
-      
+          name: artifacts
+      - run: tar -xvf distributions/skw.tar
+
       # Integrate test
       - run: |
           mkdir -p github_actions/nest
@@ -78,7 +81,7 @@ jobs:
           echo ${{ github.sha }} > github_actions/nest/${{ github.run_number }}.txt
       - name: Upload wildcard paths
         run: |
-          java -jar skw.jar upload \
+          ./skw/bin/skw upload \
             -b "$BUCKET" \
             -k "$KEY" \
             -p "java${{ matrix.java }}" \
@@ -86,7 +89,7 @@ jobs:
             ./github_actions/*.txt
       - name: Upload glob paths
         run: |
-          java -jar skw.jar upload \
+          ./skw/bin/skw upload \
             -b "$BUCKET" \
             -k "$KEY" \
             -p "java${{ matrix.java }}" \
@@ -94,16 +97,16 @@ jobs:
             ./github_actions/**/*.txt
       - name: list keys
         run: |
-          java -jar skw.jar keys \
+          ./skw/bin/skw keys \
             -b "$BUCKET" \
       - name: list tags
         run: |
-          java -jar skw.jar tags \
+          ./skw/bin/skw tags \
             -b "$BUCKET" \
             "$KEY"
       - name: Download
         run: |
-          java -jar skw.jar download \
+          ./skw/bin/skw download \
             -b "$BUCKET" \
             -k "$KEY" \
             -t "${{ github.sha }}-java${{ matrix.java }}" \
@@ -128,14 +131,15 @@ jobs:
           java-version: 1.8
       - uses: actions/download-artifact@v2
         with:
-          name: jars
+          name: artifacts
+      - run: tar -xvf distributions/skw.tar
 
       # Execute
       - name: Upload own jar to GCS
         run: |
-          java -jar skw.jar upload \
+          ./skw/bin/skw upload \
             -b "kesin11_bazel_cache" \
             -k "dogfooding" \
             -t "${{ github.sha }}" -t "latest" \
             -p "dogfooding/${{ github.run_number }}" \
-            ./skw.jar
+            ./libs/skw.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,8 @@ application {
     mainClassName = "MainKt"
 }
 
+// ---- Dependencies
+
 repositories {
     mavenCentral()
     maven(url = "https://kotlin.bintray.com/kotlinx")
@@ -45,24 +47,40 @@ dependencyLocking {
     lockAllConfigurations()
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
+// ---- Kotlin
 
 tasks.withType<KotlinCompile>() {
     kotlinOptions.jvmTarget = "1.8"
 }
 
-// Disable default jar task and build only fat jar
-tasks.named("jar") {
-    enabled = false
-}
+// ---- Create jar archives
+
 tasks.named("shadowJar", ShadowJar::class.java) {
     manifest {
         attributes["Main-Class"] = "MainKt"
     }
-    archiveFileName.set("skw.jar")
+    archiveBaseName.set("skw")
+    archiveClassifier.set("")
+    archiveVersion.set("")
     minimize()
+}
+
+distributions {
+    create("archive") {
+        // Set archive name to skw.(tar|zip)
+        distributionBaseName.set("skw")
+        version = ""
+        // Copy lib/ and bin/ directory that made by shadow
+        contents {
+            from(tasks["installShadowDist"].outputs)
+        }
+    }
+}
+
+// ---- Test and check
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.withType<Test> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 
-rootProject.name = "SkyWarehouse"
+rootProject.name = "skw"
 
 plugins {
     id("io.perezalcolea.gcs-build-cache") version "0.1.0"


### PR DESCRIPTION
Create archives for Linux users who want to install skw without homebrew.
The archives include an executable shell script that wrapped jar file.

Manual install step are unarchive it and put wrapper script to /usr/local/bin or $HOME/bin and jar to /usr/local/lib or $HOME/lib.