### PR TITLE
upload command supports multiple path and glob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
             -b "$BUCKET" \
             -k "$KEY" \
             -p "java${{ matrix.java }}" \
-            -t "${{ github.sha }}-java${{ matrix.java }}" -t "java${{ matrix.java }}" \
-            ./github_actions/**/*.txt
+            -t "${{ github.sha }}-java${{ matrix.java }}-nest" -t "java${{ matrix.java }}" \
+            ./github_actions/*.txt ./github_actions/**/*.txt
       - name: list keys
         run: |
           ./skw/bin/skw keys \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-    - "*"
     paths-ignore:
     - '**.md'
 

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -21,7 +21,7 @@ fun main(args: Array<String>) {
     lateinit var logger: Logger
 
     class UploadCommand : Subcommand("upload", "Upload files to cloud storage and register index key and tags") {
-        val pathsOrGlob: List<String> by argument(ArgType.String, description = "Paths or file glob").multiple(10000)
+        val pathOrGlobList: List<String> by argument(ArgType.String, description = "Paths or file glob").multiple(10000)
         val key: String by option(ArgType.String, shortName = "k", description = "Key").required()
         val tags: List<String> by option(
             ArgType.String,
@@ -34,12 +34,12 @@ fun main(args: Array<String>) {
             // Upload
             runCatching {
                 val storage = Storage(bucketName, logger)
-                storage.upload(pathsOrGlob, key, tags, prefix)
+                storage.upload(pathOrGlobList, key, tags, prefix)
             }.onSuccess { blobs ->
                 logger.log("Success upload to remote:")
                 logger.log(blobs.joinToString("\n") { it.name })
             }.onFailure {
-                logger.warn("Failed upload $pathsOrGlob. Error:")
+                logger.warn("Failed upload $pathOrGlobList. Error:")
                 logger.warn(it)
                 logger.warn(it.stackTraceToString())
                 kotlin.system.exitProcess(1)

--- a/src/test/kotlin/PathUtilKtTest.kt
+++ b/src/test/kotlin/PathUtilKtTest.kt
@@ -25,6 +25,15 @@ internal class PathUtilKtTest {
 
     @Nested
     class TestResolvePathsOrGlob {
+        private val ktPathsFixture = listOf(
+            Paths.get("sample", "foo.kt"),
+            Paths.get("sample", "bar.kt"),
+        )
+        private val nestJavaPathsFixture = listOf(
+            Paths.get("sample", "nest", "foo.java"),
+            Paths.get("sample", "nest", "bar.java"),
+        )
+
         @Test
         fun unixPaths() {
             val actual = resolvePathsOrGlob(listOf("sample/foo.kt", "sample/bar.kt"))
@@ -54,18 +63,13 @@ internal class PathUtilKtTest {
         fun globMatch() {
             val rootDirPath = Paths.get(".")
             mockkStatic(::filesWalk)
-            every { filesWalk(rootDirPath) } returns listOf(
-                Paths.get("sample", "foo.kt"),
-                Paths.get("sample", "bar.kt"),
-                Paths.get("sample", "bar.java")
+            every { filesWalk(rootDirPath) } returns (
+                ktPathsFixture + nestJavaPathsFixture
             ).stream()
 
             val actual = resolvePathsOrGlob(listOf("**/*.kt"))
             assertEquals(
-                listOf(
-                    Paths.get("sample", "foo.kt"),
-                    Paths.get("sample", "bar.kt")
-                ),
+                ktPathsFixture,
                 actual
             )
         }

--- a/src/test/kotlin/PathUtilKtTest.kt
+++ b/src/test/kotlin/PathUtilKtTest.kt
@@ -10,11 +10,10 @@ import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.IllegalArgumentException
+import java.util.stream.Stream
 import kotlin.test.assertEquals
 
 internal class PathUtilKtTest {
-
     @BeforeEach
     fun setUp() {
     }
@@ -33,10 +32,20 @@ internal class PathUtilKtTest {
             Paths.get("sample", "nest", "foo.java"),
             Paths.get("sample", "nest", "bar.java"),
         )
+        private fun createPathsFixtureStream(): Stream<Path> {
+            return (ktPathsFixture + nestJavaPathsFixture).stream()
+        }
+
+        @Test
+        fun emptyPath() {
+            assertThrows<IllegalArgumentException>("Paths or glob is empty.") {
+                resolvePathOrGlobList(listOf())
+            }
+        }
 
         @Test
         fun unixPaths() {
-            val actual = resolvePathsOrGlob(listOf("sample/foo.kt", "sample/bar.kt"))
+            val actual = resolvePathOrGlobList(listOf("sample/foo.kt", "sample/bar.kt"))
             assertEquals(
                 listOf(
                     Paths.get("sample", "foo.kt"),
@@ -49,7 +58,7 @@ internal class PathUtilKtTest {
         @Test
         @EnabledOnOs(OS.WINDOWS)
         fun windowsPaths() {
-            val actual = resolvePathsOrGlob(listOf("sample\\foo.kt", "sample\\bar.kt"))
+            val actual = resolvePathOrGlobList(listOf("sample\\foo.kt", "sample\\bar.kt"))
             assertEquals(
                 listOf(
                     Paths.get("sample", "foo.kt"),
@@ -63,11 +72,9 @@ internal class PathUtilKtTest {
         fun globMatch() {
             val rootDirPath = Paths.get(".")
             mockkStatic(::filesWalk)
-            every { filesWalk(rootDirPath) } returns (
-                ktPathsFixture + nestJavaPathsFixture
-            ).stream()
+            every { filesWalk(rootDirPath) } answers { createPathsFixtureStream() }
 
-            val actual = resolvePathsOrGlob(listOf("**/*.kt"))
+            val actual = resolvePathOrGlobList(listOf("**/*.kt"))
             assertEquals(
                 ktPathsFixture,
                 actual
@@ -78,29 +85,36 @@ internal class PathUtilKtTest {
         fun globMatchNoting() {
             val rootDirPath = Paths.get(".")
             mockkStatic(::filesWalk)
-            every { filesWalk(rootDirPath) } returns listOf(
-                Paths.get("sample", "foo.kt"),
-                Paths.get("sample", "bar.kt"),
-                Paths.get("sample", "bar.java")
-            ).stream()
+            every { filesWalk(rootDirPath) } answers { createPathsFixtureStream() }
 
-            val actual = resolvePathsOrGlob(listOf("**/noting"))
-            assertEquals(listOf<Path>(), actual)
+            val actual = resolvePathOrGlobList(listOf("**/noting"))
+            assertEquals(listOf(), actual)
         }
 
         @Test
-        fun globMultiThrowsError() {
+        fun globMulti() {
             val rootDirPath = Paths.get(".")
             mockkStatic(::filesWalk)
-            every { filesWalk(rootDirPath) } returns listOf(
-                Paths.get("sample", "foo.kt"),
-                Paths.get("sample", "bar.kt"),
-                Paths.get("sample", "bar.java")
-            ).stream()
+            every { filesWalk(rootDirPath) } answers { createPathsFixtureStream() }
 
-            assertThrows<IllegalArgumentException>("Multiple globs does not supported") {
-                resolvePathsOrGlob(listOf("**/first", "**/second"))
-            }
+            val actual = resolvePathOrGlobList(listOf("**/*.kt", "**/*.java"))
+            assertEquals(
+                ktPathsFixture + nestJavaPathsFixture,
+                actual
+            )
+        }
+
+        @Test
+        fun combinePathsAndGlobs() {
+            val rootDirPath = Paths.get(".")
+            mockkStatic(::filesWalk)
+            every { filesWalk(rootDirPath) } answers { createPathsFixtureStream() }
+
+            val actual = resolvePathOrGlobList(listOf("sample/foo.kt", "sample/bar.kt", "**/*.java"))
+            assertEquals(
+                ktPathsFixture + nestJavaPathsFixture,
+                actual
+            )
         }
     }
 
@@ -125,6 +139,16 @@ internal class PathUtilKtTest {
         fun multiPrefix() {
             val actual = globRootDirPath("sample/foo/**/*.kt")
             assertEquals(Paths.get("sample", "foo"), actual)
+        }
+    }
+
+    @Nested
+    class TestNormalizeGlob {
+        @Test
+        @DisplayName("./**/*")
+        fun redundantPrefix() {
+            val actual = normalizeGlob("./**/*")
+            assertEquals("**/*", actual)
         }
     }
 }


### PR DESCRIPTION
Previously `upload` command does not support multiple paths and globs and throws the error when arg has more than two globs.
Now, `upload` supports multiple paths and globls.